### PR TITLE
Fix Dates / Bluetooh MAC / dir creation

### DIFF
--- a/omramin.py
+++ b/omramin.py
@@ -526,10 +526,12 @@ def sync_bp_measurements(
                 timestamp=datetimeStr, systolic=bpm.systolic, diastolic=bpm.diastolic, pulse=bpm.pulse, notes=notes
             )
 
+def patch_date(input_date: str):
+    return input_date.split("T")[0]
 
 def garmin_get_bp_measurements(gc: GC.Garmin, startdate: str, enddate: str):
     # search dates are in local time
-    gcData = gc.get_blood_pressure(startdate=startdate, enddate=enddate)
+    gcData = gc.get_blood_pressure(startdate=patch_date(startdate), enddate=patch_date(enddate))
 
     # reduce to list of measurements
     _gcMeasurements = [metric for x in gcData["measurementSummaries"] for metric in x["measurements"]]
@@ -746,9 +748,9 @@ def add_device(
         macaddr = inquirer.list_input("Select device", choices=sorted(bleDevices))
 
     if macaddr:
-        if not U.is_valid_macaddr(macaddr):
-            L.error(f"Invalid MAC address: {macaddr}")
-            return
+        # if not U.is_valid_macaddr(macaddr):
+        #     L.error(f"Invalid MAC address: {macaddr}")
+        #     return
 
         if macaddr in [d["macaddr"] for d in devices]:
             L.info(f"Device '{macaddr}' already exists.")


### PR DESCRIPTION
# Fixes the following

1. `~/.omramin` directory creation if absent
2. On my Macbook the BPM address is returned in different format - remove Mac Address verification 
```
[2025-09-24 10:11:29] [I] Press Ctrl+C to stop scanning
[2025-09-24 10:11:30] [I] + 1BA087DC-8B9C-C629-4499-2A79524769F4 BLEsmart_0000026428FFB2CFDAED feff1ba087dc-8b9c-c629-4499-2a79524769f4 -48
```
3. Fix dates format for Garmin connect (maybe related to PL region)